### PR TITLE
Setting to avoid "Failed to fetch" error

### DIFF
--- a/systemd/stremio-server.service
+++ b/systemd/stremio-server.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Stremio Media Server
 PartOf=graphical-session.target
-Wants=network-online.target graphical.target
-After=network.target network-online.target graphical.target
+Wants=multi-user.target
+After=multi-user.target
 
 [Service]
 Environment=PATH=/home/__USER__/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
Apparently with the current configuration, there are conflicts on stremio-server startup.
If we enter multi-user.target as a dependency, the server has no problem starting.

Tested on a RaspberryPI 4 with Raspbian 10.