### PR TITLE
VLC Issues Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Open second terminal and run
 ```    
 
 ###  After verification if desired, set Stremio to auto start on boot     
-There will be a minor delay between the launch of Server Service and Client Service. This is to ensure that the Client starts after the Server.    
+There will be a minor delay ~1Min between the launch of Server Service and Client Service. This is to ensure that the Client starts after the Server.    
 Run the service installer  
 ```   
 sudo /home/${USER}/Stremio-RaspberryPi/scripts/service-installer.sh        
@@ -58,3 +58,4 @@ In that, Navigate to Advanced Options -> Compositor -> xcompmgr composition mana
 ### Note     
  - If you have closed or stopped the background Stremio services, then if you wish to start them again, you can use the service desktop shortcuts.    
  - You can manually start the Stremio server and client using the Stremio Launcher desktop shortcuts.     
+ - If your cursor is stuck after running ```systemctl --user start stremio-server.service```, press Ctrl+C on keyboard to break free.   

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Stremio-RaspberryPi    
+### **If you like the work and if you would like to get me a :coffee: :smile:** [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7GH3YDCHZ36QN)    
 
 ## Steps to run Stremio in Raspberry Pi   
 
@@ -20,7 +21,7 @@ sudo chmod +x /home/${USER}/Stremio-RaspberryPi/src/client-launcher.sh
 sudo /home/${USER}/Stremio-RaspberryPi/scripts/installer.sh
 ```   
 
-###  After the installation, try opening the Stremio server and client manually using the following   
+###  After the installation, try opening the Stremio server and client manually using the following commands or use the Launcher Shortcuts created on the desktop      
 Open first terminal and run    
 ```   
 /home/${USER}/Stremio-RaspberryPi/src/server-launcher.sh  
@@ -31,7 +32,8 @@ Open second terminal and run
 /home/${USER}/Stremio-RaspberryPi/src/client-launcher.sh  
 ```    
 
-###  After verification if desired, set Stremio to auto start on boot (VLC controls do not work on auto start)   
+###  After verification if desired, set Stremio to auto start on boot     
+There will be a minor delay between the launch of Server Service and Client Service. This is to ensure that the Client starts after the Server.    
 Run the service installer  
 ```   
 sudo /home/${USER}/Stremio-RaspberryPi/scripts/service-installer.sh        
@@ -39,10 +41,10 @@ sudo /home/${USER}/Stremio-RaspberryPi/scripts/service-installer.sh
 
 Enable and start the service   
 ```   
-sudo systemctl enable stremio-server.service   
-sudo systemctl enable stremio-client.service   
-sudo systemctl start stremio-server.service   
-sudo systemctl start stremio-client.service  
+systemctl --user enable stremio-server.service
+systemctl --user enable stremio-client.service
+systemctl --user start stremio-server.service
+systemctl --user start stremio-client.service
 ```    
 
 ### Fix for screen tearing    
@@ -54,10 +56,5 @@ In that, Navigate to Advanced Options -> Compositor -> xcompmgr composition mana
 
 
 ### Note     
- - If you want to play videos using VLC:      
-   1. DO NOT set the Stremio Server and Client to auto start on boot.
-   2. Use the shortcuts on the Desktop or the commands given above to manually launch the Service and Client.
-   3. Always launch the Server first and after a couple of seconds, launch the Client.     
- - If you have enabled the Client Service and exited the Stremio interface in the browser, open a terminal and run ```sudo systemctl restart stremio-client.service```.   
- - If you did not enable the Client Service and exited the Stremio interface in the browser, use the Client-Launcher shortcut on the Desktop to start the client again.    
- - If you are using Stremio server for remote access i.e, to use it from iPad, iPhone, Android Devices, etc, you can have the server set to auto start on boot.     
+ - If you have closed or stopped the background Stremio services, then if you wish to start them again, you can use the service desktop shortcuts.    
+ - You can manually start the Stremio server and client using the Stremio Launcher desktop shortcuts.     

--- a/scripts/Stremio-Client-Service-Shortcut.sh
+++ b/scripts/Stremio-Client-Service-Shortcut.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl --user restart stremio-client.service

--- a/scripts/Stremio-Server-Service-Shortcut.sh
+++ b/scripts/Stremio-Server-Service-Shortcut.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl --user restart stremio-server.service

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -36,12 +36,17 @@ echo ""
 sed -i 's/__USER__/'${USER}'/g' ${GIT_DIR}/systemd/stremio-client.service
 sed -i 's/__USER__/'${USER}'/g' ${GIT_DIR}/systemd/stremio-server.service
 echo ""
-echo "Creating desktop shortcuts for starting client ............."
+echo "Creating desktop shortcuts ............."
 echo ""
 echo ""
+sudo chmod +x ${GIT_DIR}/scripts/Stremio-Server-Service-Shortcut.sh
+sudo chmod +x ${GIT_DIR}/scripts/Stremio-Client-Service-Shortcut.sh
 sudo chmod +x ${GIT_DIR}/src/client-launcher.sh
-sudo \cp ${GIT_DIR}/src/server-launcher.sh /home/${USER}/Desktop/Stremio-Server-Launcher-Shortcut
-sudo \cp ${GIT_DIR}/src/client-launcher.sh /home/${USER}/Desktop/Stremio-Client-Launcher-Shortcut
+sudo chmod +x ${GIT_DIR}/src/server-launcher.sh
+sudo \cp ${GIT_DIR}/scripts/Stremio-Server-Service-Shortcut.sh /home/${USER}/Desktop/Stremio-Server-Service
+sudo \cp ${GIT_DIR}/scripts/Stremio-Client-Service-Shortcut.sh /home/${USER}/Desktop/Stremio-Client-Service
+sudo \cp ${GIT_DIR}/src/server-launcher.sh /home/${USER}/Desktop/Stremio-Server-Launcher
+sudo \cp ${GIT_DIR}/src/client-launcher.sh /home/${USER}/Desktop/Stremio-Client-Launcher
 echo ""
 echo ""
 echo "Finished installing. Sit back and enjoy the show............."

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -6,8 +6,6 @@
 
 echo ""
 echo ""
-echo "Get your popcorn while we prep your Pi......"
-echo ""
 set -o errexit
 
 scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
@@ -20,7 +18,9 @@ then
     echo "This script must run as $RUN_AS, trying to change user..."
     exec sudo -u $RUN_AS $0
 fi
-
+echo "Get your popcorn while we prep your Pi......"
+echo ""
+echo ""
 echo "Updating the OS......."
 echo ""
 sudo apt-get update -y

--- a/scripts/service-installer.sh
+++ b/scripts/service-installer.sh
@@ -23,5 +23,5 @@ repo_path="$PWD"
 
 for service in systemd/*.service; do
 	sed "s:/home/__USER__/Stremio-RaspberryPi:${repo_path}:g;s:__USER__:${GIT_OWNER}:g" "$service" \
-	 > "/lib/systemd/system/$(basename "$service")"
+	 > "/etc/systemd/user/$(basename "$service")"
 done

--- a/src/client-launcher.sh
+++ b/src/client-launcher.sh
@@ -6,4 +6,4 @@
 
 
 # Run Chromium and open tabs
-/usr/bin/chromium-browser --app=https://app.strem.io/shell-v4.4/ --window-position=0,0 --start-fullscreen --use-gl=egl     
+/usr/bin/chromium-browser --app=https://app.strem.io/shell-v4.4/ --window-position=0,0 --start-fullscreen --use-gl=angle

--- a/systemd/stremio-client.service
+++ b/systemd/stremio-client.service
@@ -1,19 +1,14 @@
 [Unit]
 Description=Stremio Media Client
-PartOf=graphical-session.target
-Wants=stremio-server.service graphical.target
-After=stremio-server.service graphical.target
+Wants=stremio-server.service network-online.target graphical.target
+After=stremio-server.service network-online.target graphical.target
 
 [Service]
+Type=forking
 Environment=DISPLAY=:0.0
 Environment=XAUTHORITY=/home/__USER__/.Xauthority
-ExecStart=/home/__USER__/Stremio-RaspberryPi/src/client-launcher.sh
+ExecStart=/usr/bin/bash /home/__USER__/Stremio-RaspberryPi/src/client-launcher.sh
 
-WorkingDirectory=/home/__USER__/
-StandardOutput=inherit
-StandardError=inherit
-Restart=on-failure
-User=__USER__
 
 [Install]
-WantedBy=graphical.target
+WantedBy=default.target

--- a/systemd/stremio-server.service
+++ b/systemd/stremio-server.service
@@ -1,18 +1,12 @@
 [Unit]
 Description=Stremio Media Server
-PartOf=graphical-session.target
-Wants=multi-user.target
-After=multi-user.target
+Wants=network-online.target graphical.target
+After=network-online.target graphical.target
 
 [Service]
-Environment=PATH=/home/__USER__/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart=/home/__USER__/Stremio-RaspberryPi/src/server-launcher.sh
-
-WorkingDirectory=/home/__USER__/
-StandardOutput=inherit
-StandardError=inherit
-User=__USER__
-Restart=on-failure
+Type=forking
+ExecStart=/usr/bin/bash /home/__USER__/Stremio-RaspberryPi/src/server-launcher.sh
+Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Fixes #25  Fixes #1 
1. Services are run as user and not as root user.
2. VLC and other media player controls work even for services.
3. A minor delay has been introduced to the start of client service.
